### PR TITLE
Update SwiftSyntax version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["SwiftSyntaxExtensions"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50100.0")),
+        .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50200.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/SwiftSyntaxExtensions/ProtocolDeclSyntax+Property.swift
+++ b/Sources/SwiftSyntaxExtensions/ProtocolDeclSyntax+Property.swift
@@ -11,9 +11,9 @@ import SwiftSyntax
 extension ProtocolDeclSyntax {
     public func extractVariableDecl() -> [(IdentifierPatternSyntax, TypeAnnotationSyntax)] {
         return self.members.members.compactMap { declMember in
-            guard let varDecl = declMember.decl as? VariableDeclSyntax,
-                let binding = varDecl.bindings.first(where: { $0.pattern is IdentifierPatternSyntax }),
-                let pattern = binding.pattern as? IdentifierPatternSyntax,
+            guard let varDecl = declMember.decl.as(VariableDeclSyntax.self),
+                let binding = varDecl.bindings.first(where: { $0.pattern.is(IdentifierPatternSyntax.self) }),
+                let pattern = binding.pattern.as(IdentifierPatternSyntax.self),
                 let typeAnnotation = binding.typeAnnotation else { return nil }
             return (pattern, typeAnnotation)
         }

--- a/Sources/SwiftSyntaxExtensions/TriviaPiece+Comment.swift
+++ b/Sources/SwiftSyntaxExtensions/TriviaPiece+Comment.swift
@@ -18,7 +18,6 @@ extension TriviaPiece {
              .newlines,
              .carriageReturns,
              .carriageReturnLineFeeds,
-             .backticks,
              .garbageText:
             return nil
         case .lineComment(let comment),

--- a/Sources/SwiftSyntaxExtensions/VariableDeclSyntax++Property.swift
+++ b/Sources/SwiftSyntaxExtensions/VariableDeclSyntax++Property.swift
@@ -14,8 +14,8 @@ extension VariableDeclSyntax {
     }
     
     public var variableName: String? {
-        guard let binding = self.bindings.first(where: { $0.pattern is IdentifierPatternSyntax }),
-            let pattern = binding.pattern as? IdentifierPatternSyntax else {
+        guard let binding = self.bindings.first(where: { $0.pattern.is(IdentifierPatternSyntax.self) }),
+            let pattern = binding.pattern.as(IdentifierPatternSyntax.self) else {
                 return nil
         }
         return String(pattern.identifier.text


### PR DESCRIPTION
* Updated SwiftSyntax to `0.50200.0`
* Updated type checking and casting of `DeclSyntax` to use new `is` and `as` methods ([see here](https://github.com/apple/swift-syntax/blob/master/Changelog.md#modelling-syntax-nodes-as-structs))
* Removed usage of deleted enum case `TriviaPiece.backticks`