### PR TITLE
Update SwiftSyntaxExtensions to 0.50700.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-syntax.git",
         "state": {
           "branch": null,
-          "revision": "844574d683f53d0737a9c6d706c3ef31ed2955eb",
-          "version": "0.50300.0"
+          "revision": "72d3da66b085c2299dd287c2be3b92b5ebd226de",
+          "version": "0.50700.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["SwiftSyntaxExtensions"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50300.0")),
+        .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50700.1")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
Update to avoid `No such module` error.

https://github.com/apple/swift-syntax/releases