### PR TITLE
Update SwiftSyntax version to 508.0.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-syntax.git",
         "state": {
           "branch": null,
-          "revision": "844574d683f53d0737a9c6d706c3ef31ed2955eb",
-          "version": "0.50300.0"
+          "revision": "cd793adf5680e138bf2bcbaacc292490175d0dcd",
+          "version": "508.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,13 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "SwiftSyntaxExtensions",
+    platforms: [
+        .macOS(.v10_15)
+    ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
@@ -12,7 +15,7 @@ let package = Package(
             targets: ["SwiftSyntaxExtensions"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50300.0")),
+        .package(url: "https://github.com/apple/swift-syntax.git", .exact("508.0.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/SwiftSyntaxExtensions/TriviaPiece+Comment.swift
+++ b/Sources/SwiftSyntaxExtensions/TriviaPiece+Comment.swift
@@ -17,13 +17,14 @@ extension TriviaPiece {
              .formfeeds,
              .newlines,
              .carriageReturns,
-             .carriageReturnLineFeeds,
-             .garbageText:
+             .carriageReturnLineFeeds:
             return nil
         case .lineComment(let comment),
              .blockComment(let comment),
              .docLineComment(let comment),
-             .docBlockComment(let comment):
+             .docBlockComment(let comment),
+             .shebang(let comment),
+             .unexpectedText(let comment):
             return comment
         }
     }


### PR DESCRIPTION
Needed to resolve the `No such module.` issue for `_InternalSwiftSyntaxParser`.

https://github.com/apple/swift-syntax/releases